### PR TITLE
Mark core::Device related signals as private

### DIFF
--- a/lmrs/esu/lp2device.cpp
+++ b/lmrs/esu/lp2device.cpp
@@ -830,7 +830,7 @@ void Device::updateDeviceInfo()
                 qCWarning(logger(this)) << "Unsupported interface info:" << it.key();
         }
 
-        emit deviceInfoChanged(d->deviceInfo.keys());
+        emit deviceInfoChanged(d->deviceInfo.keys(), {});
     });
 }
 
@@ -838,10 +838,10 @@ void Device::setDeviceInfo(core::DeviceInfo id, QVariant value)
 {
     if (auto it = d->deviceInfo.find(id); it == d->deviceInfo.end()) {
         d->deviceInfo.insert(id, std::move(value));
-        emit deviceInfoChanged({id});
+        emit deviceInfoChanged({id}, {});
     } else if (*it != value) {
         *it = std::move(value);
-        emit deviceInfoChanged({id});
+        emit deviceInfoChanged({id}, {});
     }
 }
 

--- a/lmrs/kpfzeller/scdevice.cpp
+++ b/lmrs/kpfzeller/scdevice.cpp
@@ -215,9 +215,9 @@ void SpeedCatDevice::SpeedMeter::addMeasurement(unsigned pulseCount)
     if (sampleCount < samples.size())
         ++sampleCount;
 
-    const auto now = Sample::Timestamp::clock::now();
+    auto now = Sample::Timestamp::clock::now();
     samples[currentSample] = {now, pulseCount};
-    emit dataReceived(now);
+    emit dataReceived(std::move(now), {});
 }
 
 core::SpeedMeterControl::Features SpeedCatDevice::SpeedMeter::features() const

--- a/lmrs/roco/z21client.cpp
+++ b/lmrs/roco/z21client.cpp
@@ -865,97 +865,97 @@ Client::Private::Private(Client *parent)
 void Client::Private::setTrackStatus(TrackStatus trackStatus)
 {
     if (std::exchange(m_deviceInfo.trackStatus, trackStatus) != trackStatus)
-        emit q()->trackStatusChanged(m_deviceInfo.trackStatus);
+        emit q()->trackStatusChanged(m_deviceInfo.trackStatus, {});
 }
 
 void Client::Private::setCentralStatus(CentralStatus centralStatus)
 {
     if (std::exchange(m_deviceInfo.centralStatus, centralStatus) != centralStatus)
-        emit q()->centralStatusChanged(m_deviceInfo.centralStatus);
+        emit q()->centralStatusChanged(m_deviceInfo.centralStatus, {});
 }
 
 void Client::Private::setCapabilities(Capabilities capabilities)
 {
     if (std::exchange(m_deviceInfo.capabilities, capabilities) != capabilities)
-        emit q()->capabilitiesChanged(m_deviceInfo.capabilities);
+        emit q()->capabilitiesChanged(m_deviceInfo.capabilities, {});
 }
 
 void Client::Private::setSubscriptions(Subscriptions subscriptions)
 {
     if (std::exchange(m_deviceInfo.subscriptions, subscriptions) != subscriptions)
-        emit q()->subscriptionsChanged(m_deviceInfo.subscriptions);
+        emit q()->subscriptionsChanged(m_deviceInfo.subscriptions, {});
 }
 
 void Client::Private::setSerialNumber(quint32 serialNumber)
 {
     if (std::exchange(m_deviceInfo.serialNumber, serialNumber) != serialNumber)
-        emit q()->serialNumberChanged(m_deviceInfo.serialNumber);
+        emit q()->serialNumberChanged(m_deviceInfo.serialNumber, {});
 }
 
 void Client::Private::setFirmwareVersion(QVersionNumber firmwareVersion)
 {
     if (std::exchange(m_deviceInfo.firmwareVersion, firmwareVersion) != firmwareVersion)
-        emit q()->firmwareVersionChanged(m_deviceInfo.firmwareVersion);
+        emit q()->firmwareVersionChanged(m_deviceInfo.firmwareVersion, {});
 }
 
 void Client::Private::setProtocolVersion(QVersionNumber protocolVersion)
 {
     if (std::exchange(m_deviceInfo.protocolVersion, protocolVersion) != protocolVersion)
-        emit q()->protocolVersionChanged(m_deviceInfo.protocolVersion);
+        emit q()->protocolVersionChanged(m_deviceInfo.protocolVersion, {});
 }
 
 void Client::Private::setCentralId(int centralId)
 {
     if (std::exchange(m_deviceInfo.centralId, centralId) != centralId)
-        emit q()->centralIdChanged(m_deviceInfo.centralId);
+        emit q()->centralIdChanged(m_deviceInfo.centralId, {});
 }
 
 void Client::Private::setMainTrackCurrent(core::milliamperes mainTrackCurrent)
 {
     if (std::exchange(m_deviceInfo.mainTrackCurrent, mainTrackCurrent) != mainTrackCurrent)
-        emit q()->mainTrackCurrentChanged(m_deviceInfo.mainTrackCurrent);
+        emit q()->mainTrackCurrentChanged(m_deviceInfo.mainTrackCurrent, {});
 }
 
 void Client::Private::setProgrammingTrackCurrent(core::milliamperes programmingTrackCurrent)
 {
     if (std::exchange(m_deviceInfo.programmingTrackCurrent, programmingTrackCurrent) != programmingTrackCurrent)
-        emit q()->programmingTrackCurrentChanged(m_deviceInfo.programmingTrackCurrent);
+        emit q()->programmingTrackCurrentChanged(m_deviceInfo.programmingTrackCurrent, {});
 }
 
 void Client::Private::setFilteredMainTrackCurrent(core::milliamperes filteredMainTrackCurrent)
 {
     if (std::exchange(m_deviceInfo.filteredMainTrackCurrent, filteredMainTrackCurrent) != filteredMainTrackCurrent)
-        emit q()->filteredMainTrackCurrentChanged(m_deviceInfo.filteredMainTrackCurrent);
+        emit q()->filteredMainTrackCurrentChanged(m_deviceInfo.filteredMainTrackCurrent, {});
 }
 
 void Client::Private::setTemperature(core::celsius temperature)
 {
     if (std::exchange(m_deviceInfo.temperature, temperature) != temperature)
-        emit q()->temperatureChanged(m_deviceInfo.temperature);
+        emit q()->temperatureChanged(m_deviceInfo.temperature, {});
 }
 
 void Client::Private::setSupplyVoltage(core::millivolts supplyVoltage)
 {
     if (std::exchange(m_deviceInfo.supplyVoltage, supplyVoltage) != supplyVoltage)
-        emit q()->supplyVoltageChanged(m_deviceInfo.supplyVoltage);
+        emit q()->supplyVoltageChanged(m_deviceInfo.supplyVoltage, {});
 }
 
 void Client::Private::setTrackVoltage(core::millivolts trackVoltage)
 {
     if (std::exchange(m_deviceInfo.trackVoltage, trackVoltage) != trackVoltage)
-        emit q()->trackVoltageChanged(m_deviceInfo.trackVoltage);
+        emit q()->trackVoltageChanged(m_deviceInfo.trackVoltage, {});
 }
 
 void Client::Private::setHardwareType(HardwareType hardwareType)
 {
     if (std::exchange(m_deviceInfo.hardwareType, hardwareType) != hardwareType)
-        emit q()->hardwareTypeChanged(m_deviceInfo.hardwareType);
+        emit q()->hardwareTypeChanged(m_deviceInfo.hardwareType, {});
 }
 
 void Client::Private::setLockState(LockState lockState)
 {
     if (std::exchange(m_deviceInfo.lockState, lockState) != lockState)
-        emit q()->lockStateChanged(m_deviceInfo.lockState);
+        emit q()->lockStateChanged(m_deviceInfo.lockState, {});
 }
 
 void Client::Private::connectToHost(QHostAddress host, quint16 port)
@@ -994,7 +994,7 @@ void Client::Private::disconnectFromHost()
     resetObservers();
 
     if (isConnectedGuard.hasChanged())
-        emit q()->disconnected();
+        emit q()->disconnected({});
 }
 
 void Client::Private::sendRequest(QByteArray request, Observer observer)
@@ -1195,7 +1195,7 @@ void Client::Private::stopConnectTimeout()
 void Client::Private::reportError(Error error)
 {
     qCWarning(logger()) << "An error occured:" << error;
-    emit q()->errorOccured(error);
+    emit q()->errorOccured(error, {});
 }
 
 void Client::Private::queueCanDetectorInfoCallback(can::NetworkId networkId, CanDetectorInfoCallback callback)
@@ -1490,8 +1490,8 @@ void Client::Private::maybeEmitCanDetectorInfo(can::NetworkId networkId, const C
                 << Qt::endl << "FOO:CAN:" << infoList
                 << Qt::endl << "FOO:generic:" << genericInfo;
 
-        emit q()->canDetectorInfoReceived(std::move(infoList));
-        emit q()->detectorInfoReceived(std::move(genericInfo));
+        emit q()->canDetectorInfoReceived(std::move(infoList), {});
+        emit q()->detectorInfoReceived(std::move(genericInfo), {});
     }
 }
 
@@ -1508,7 +1508,7 @@ void Client::Private::emitPendingLoconetDetectorInfo()
 void Client::Private::parseBroadcasts(Message message)
 {
     if (const auto info = parseVehicleInfo(message)) {
-        emit q()->vehicleInfoReceived(info.value());
+        emit q()->vehicleInfoReceived(info.value(), {});
         return;
     }
 
@@ -1517,7 +1517,7 @@ void Client::Private::parseBroadcasts(Message message)
     case 11:
     case 17:
         if (const auto info = parseRailcomInfo(std::move(message)); info && info->isValid())
-            emit q()->railcomInfoReceived(info.value());
+            emit q()->railcomInfoReceived(info.value(), {});
 
         break;
 
@@ -1554,7 +1554,7 @@ void Client::Private::parseBroadcasts(Message message)
         if (const auto info = parseLoconetDetectorInfo(message))
             mergeLoconetDetectorInfo(info.value());
         else if (const auto info = parseTurnoutInfo(std::move(message)))
-            emit q()->turnoutInfoReceived(info.value());
+            emit q()->turnoutInfoReceived(info.value(), {});
 
         break;
 
@@ -1562,7 +1562,7 @@ void Client::Private::parseBroadcasts(Message message)
         if (const auto info = parseLoconetDetectorInfo(message))
             mergeLoconetDetectorInfo(info.value());
         else if (const auto info = parseAccessoryInfo(std::move(message)))
-            emit q()->accessoryInfoReceived(info.value());
+            emit q()->accessoryInfoReceived(info.value(), {});
 
         break;
 
@@ -1574,13 +1574,13 @@ void Client::Private::parseBroadcasts(Message message)
 
     case 15:
         if (const auto info = parseRBusDetectorInfo(std::move(message)))
-            emit q()->rbusDetectorInfoReceived(info.value());
+            emit q()->rbusDetectorInfoReceived(info.value(), {});
 
         break;
 
     case 16:
         if (const auto info = parseLibraryInfo(std::move(message)))
-            emit q()->libraryInfoReceived(info.value());
+            emit q()->libraryInfoReceived(info.value(), {});
 
         break;
 
@@ -2003,7 +2003,7 @@ void Client::queryVehicle(quint16 address, std::function<void(VehicleInfo)> call
     d->sendRequest(std::move(request), [this, callback](auto message) {
         if (const auto info = d->parseVehicleInfo(std::move(message))) {
             callIfDefined(callback, info.value());
-            emit vehicleInfoReceived(info.value());
+            emit vehicleInfoReceived(info.value(), {});
             return true;
         }
 
@@ -2027,7 +2027,7 @@ void Client::queryAccessoryInfo(dcc::AccessoryAddress address, std::function<voi
             if (info->address() == address)
                 callIfDefined(callback, info.value());
 
-            emit accessoryInfoReceived(info.value());
+            emit accessoryInfoReceived(info.value(), {});
             return true;
         }
 
@@ -2046,7 +2046,7 @@ void Client::queryTurnoutInfo(dcc::AccessoryAddress address, std::function<void 
             if (info->address() == address)
                 callIfDefined(callback, info.value());
 
-            emit turnoutInfoReceived(info.value());
+            emit turnoutInfoReceived(info.value(), {});
             return true;
         }
 
@@ -2153,7 +2153,7 @@ void Client::queryRailcom(quint16 address, std::function<void (RailcomInfo)> cal
         if (const auto info = d->parseRailcomInfo(std::move(message))) {
             if (info->address() == address) {
                 callIfDefined(callback, info.value());
-                emit railcomInfoReceived(info.value());
+                emit railcomInfoReceived(info.value(), {});
                 return true;
             } else if (!info->isValid()) {
                 return true; // FIXME: Seems we must better serialize these queries, as the empty no-railcom-message doesn't tell which request failed.
@@ -2328,7 +2328,7 @@ void Client::connectToHost(Subscriptions subscriptions, QHostAddress host, quint
     subscribe(subscriptions);
     queryTrackStatus([this](auto) {
         d->stopConnectTimeout();
-        emit connected();
+        emit connected({});
 
         // FIXME: maybe only do for black Z21
         queryCanDetectorInfo(can::NetworkIdAny, {});

--- a/lmrs/roco/z21client.h
+++ b/lmrs/roco/z21client.h
@@ -588,41 +588,41 @@ public slots:
     void disconnectFromHost();
 
 signals:
-    void errorOccured(lmrs::roco::z21::Client::Error error);
+    void errorOccured(lmrs::roco::z21::Client::Error error, QPrivateSignal);
 
-    void connected();
-    void disconnected();
+    void connected(QPrivateSignal);
+    void disconnected(QPrivateSignal);
 
-    void accessoryInfoReceived(lmrs::roco::z21::AccessoryInfo info);
-    void railcomInfoReceived(lmrs::roco::z21::RailcomInfo info);
-    void detectorInfoReceived(QList<lmrs::core::accessory::DetectorInfo> info);
-    void rbusDetectorInfoReceived(lmrs::roco::z21::RBusDetectorInfo info);
-    void loconetDetectorInfoReceived(lmrs::roco::z21::LoconetDetectorInfo info);
-    void canDetectorInfoReceived(QList<lmrs::roco::z21::CanDetectorInfo> info);
-    void turnoutInfoReceived(lmrs::roco::z21::TurnoutInfo info);
-    void vehicleInfoReceived(lmrs::roco::z21::VehicleInfo info);
-    void libraryInfoReceived(lmrs::roco::z21::LibraryInfo info);
+    void accessoryInfoReceived(lmrs::roco::z21::AccessoryInfo info, QPrivateSignal);
+    void railcomInfoReceived(lmrs::roco::z21::RailcomInfo info, QPrivateSignal);
+    void detectorInfoReceived(QList<lmrs::core::accessory::DetectorInfo> info, QPrivateSignal);
+    void rbusDetectorInfoReceived(lmrs::roco::z21::RBusDetectorInfo info, QPrivateSignal);
+    void loconetDetectorInfoReceived(lmrs::roco::z21::LoconetDetectorInfo info, QPrivateSignal);
+    void canDetectorInfoReceived(QList<lmrs::roco::z21::CanDetectorInfo> info, QPrivateSignal);
+    void turnoutInfoReceived(lmrs::roco::z21::TurnoutInfo info, QPrivateSignal);
+    void vehicleInfoReceived(lmrs::roco::z21::VehicleInfo info, QPrivateSignal);
+    void libraryInfoReceived(lmrs::roco::z21::LibraryInfo info, QPrivateSignal);
 
-    void isConnectedChanged(bool isConnected);
-    void hostAddressChanged(QHostAddress hostAddress);
-    void hostPortChanged(quint16 hostPort);
+    void isConnectedChanged(bool isConnected, QPrivateSignal);
+    void hostAddressChanged(QHostAddress hostAddress, QPrivateSignal);
+    void hostPortChanged(quint16 hostPort, QPrivateSignal);
 
-    void trackStatusChanged(lmrs::roco::z21::Client::TrackStatus trackStatus);
-    void centralStatusChanged(lmrs::roco::z21::Client::CentralStatus centralStatus);
-    void capabilitiesChanged(lmrs::roco::z21::Client::Capabilities capabilities);
-    void subscriptionsChanged(lmrs::roco::z21::Client::Subscriptions subscriptions);
-    void serialNumberChanged(quint32 serialNumber);
-    void firmwareVersionChanged(QVersionNumber firmwareVersion);
-    void protocolVersionChanged(QVersionNumber protocolVersion);
-    void centralIdChanged(int centralId);
-    void mainTrackCurrentChanged(lmrs::core::milliamperes mainTrackCurrent);
-    void programmingTrackCurrentChanged(lmrs::core::milliamperes programmingTrackCurrent);
-    void filteredMainTrackCurrentChanged(lmrs::core::milliamperes filteredMainTrackCurrent);
-    void temperatureChanged(lmrs::core::celsius temperature);
-    void supplyVoltageChanged(lmrs::core::millivolts supplyVoltage);
-    void trackVoltageChanged(lmrs::core::millivolts trackVoltage);
-    void hardwareTypeChanged(lmrs::roco::z21::Client::HardwareType hardwareType);
-    void lockStateChanged(lmrs::roco::z21::Client::LockState lockState);
+    void trackStatusChanged(lmrs::roco::z21::Client::TrackStatus trackStatus, QPrivateSignal);
+    void centralStatusChanged(lmrs::roco::z21::Client::CentralStatus centralStatus, QPrivateSignal);
+    void capabilitiesChanged(lmrs::roco::z21::Client::Capabilities capabilities, QPrivateSignal);
+    void subscriptionsChanged(lmrs::roco::z21::Client::Subscriptions subscriptions, QPrivateSignal);
+    void serialNumberChanged(quint32 serialNumber, QPrivateSignal);
+    void firmwareVersionChanged(QVersionNumber firmwareVersion, QPrivateSignal);
+    void protocolVersionChanged(QVersionNumber protocolVersion, QPrivateSignal);
+    void centralIdChanged(int centralId, QPrivateSignal);
+    void mainTrackCurrentChanged(lmrs::core::milliamperes mainTrackCurrent, QPrivateSignal);
+    void programmingTrackCurrentChanged(lmrs::core::milliamperes programmingTrackCurrent, QPrivateSignal);
+    void filteredMainTrackCurrentChanged(lmrs::core::milliamperes filteredMainTrackCurrent, QPrivateSignal);
+    void temperatureChanged(lmrs::core::celsius temperature, QPrivateSignal);
+    void supplyVoltageChanged(lmrs::core::millivolts supplyVoltage, QPrivateSignal);
+    void trackVoltageChanged(lmrs::core::millivolts trackVoltage, QPrivateSignal);
+    void hardwareTypeChanged(lmrs::roco::z21::Client::HardwareType hardwareType, QPrivateSignal);
+    void lockStateChanged(lmrs::roco::z21::Client::LockState lockState, QPrivateSignal);
 
 private:
     class Private;

--- a/lmrs/zimo/mx1device.cpp
+++ b/lmrs/zimo/mx1device.cpp
@@ -658,7 +658,7 @@ void Device::VehicleControl::updateVehicleState(dcc::VehicleAddress address, con
     switch (vehicle.subscription) {
     case core::VehicleControl::NormalSubscription:
     case core::VehicleControl::PrimarySubscription:
-        emit vehicleInfoChanged(core::VehicleInfo{address, vehicle.direction, vehicle.speed, vehicle.functions});
+        emit vehicleInfoChanged(core::VehicleInfo{address, vehicle.direction, vehicle.speed, vehicle.functions}, {});
         break;
 
     case core::VehicleControl::CancelSubscription:
@@ -781,10 +781,10 @@ void Device::Private::setDeviceInfo(core::DeviceInfo id, QVariant value)
     // FIXME: share setDeviceInfo()
     if (auto it = deviceInfo.find(id); it == deviceInfo.end()) {
         deviceInfo.insert(id, std::move(value));
-        emit q()->deviceInfoChanged({id});
+        emit q()->deviceInfoChanged({id}, {});
     } else if (*it != value) {
         *it = std::move(value);
-        emit q()->deviceInfoChanged({id});
+        emit q()->deviceInfoChanged({id}, {});
     }
 }
 


### PR DESCRIPTION
This simply is best practice.